### PR TITLE
Shortcut for adding all ManagedObject extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ import CoreDataPlus
 // An existing NSManagedObject
 public class Drawing: NSManagedObject { }
 
+extension Drawing: ManagedObjectPlus {
+                   
+}
+```
+
+You can also import just the features you want to use by replacing `ManagedObjectPlus` with one or more of the available `ManagedObject*` protocols:
+
+```swift
 extension Drawing: ManagedObjectDeletable,
                    ManagedObjectCountable,
                    ManagedObjectSearchable,

--- a/Sources/CoreDataPlus/ManagedObjectPlus.swift
+++ b/Sources/CoreDataPlus/ManagedObjectPlus.swift
@@ -1,0 +1,2 @@
+/// Shortcut for adding all ManagedObject extensions
+public typealias ManagedObjectPlus = ManagedObjectCountable & ManagedObjectDeletable & ManagedObjectSearchable & ManagedObjectFindOrCreateBy


### PR DESCRIPTION
Added a less verbose way of importing all extensions to an NSManagedObject:

```swift
public class Drawing: NSManagedObject { }

extension Drawing: ManagedObjectPlus { }
```

You can still import just the features you want to use by replacing `ManagedObjectPlus` with one or more of the available `ManagedObject*` protocols:

```swift
public class Drawing: NSManagedObject { }

extension Drawing: ManagedObjectDeletable,
                   ManagedObjectCountable,
                   ManagedObjectSearchable,
                   ManagedObjectFindOrCreateBy {
                   
}
```