### PR TITLE
- Added ability to delete only some items: `Country.destroyAll(matchi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,20 @@ for drawing in results {
 ### `destroyAll`
 
 Removes all objects from Core Data.
-*Deletes them from the context, and saves the context.*
+*Deletes them from the context.*
 
 ```swift
 Drawing.destroyAll(context: viewContext)
 ```
 
+
+You can also specify a predicate to only delete some items:
+```swift
+let withSpanishLanguage = Predicate("languages contains %@", es)
+Country.destroyAll(matching: withSpanishLanguage)
+```
+
+Remember to save the context after deleting objects.
 
 
 

--- a/Sources/CoreDataPlus/ManagedObjectDeletable.swift
+++ b/Sources/CoreDataPlus/ManagedObjectDeletable.swift
@@ -2,16 +2,32 @@ import CoreData
 import Foundation
 
 public protocol ManagedObjectDeletable {
-    /// Removes all objects from the context, and saves the context.
+    /// Removes all objects from the context
     static func destroyAll(context: NSManagedObjectContext)
+    /// Removes all objects from the foreground or background context
     static func destroyAll(using: ContextMode)
+    /// Removes all objects matching the predicate from the context
+    static func destroyAll(matching: Predicate?, context: NSManagedObjectContext)
+    /// Removes all objects matching the predicate from the foreground or background context
+    static func destroyAll(matching: Predicate?, using: ContextMode)
 }
 
 public extension ManagedObjectDeletable {
     static func destroyAll(context: NSManagedObjectContext) {
+        destroyAll(matching: nil, context: context)
+    }
+    static func destroyAll(using: ContextMode = .foreground) {
+        destroyAll(context: contextModeToNSManagedObjectContext(using))
+    }
+    static func destroyAll(matching: Predicate? = nil, using: ContextMode = .foreground) {
+        destroyAll(matching: matching, context: contextModeToNSManagedObjectContext(using))
+    }
+    static func destroyAll(matching: Predicate? = nil, context: NSManagedObjectContext) {
         let request = (self as! NSManagedObject.Type).fetchRequest()
         request.entity = (self as! NSManagedObject.Type).entity()
-
+        
+        request.predicate = matching
+        
         var objects: [Any]
         do {
             objects = try context.fetch(request)
@@ -22,10 +38,7 @@ public extension ManagedObjectDeletable {
             context.delete(obj as! NSManagedObject)
         }
     }
-    
-    static func destroyAll(using: ContextMode = .foreground) {
-        let context = contextModeToNSManagedObjectContext(using)
-        
-        destroyAll(context: context)
-    }
 }
+
+
+

--- a/Tests/CoreDataPlusTests/CoreTests.swift
+++ b/Tests/CoreDataPlusTests/CoreTests.swift
@@ -168,6 +168,51 @@ final class CoreTests: BaseTestCase {
         XCTAssertEqual(sort3, sort4)
     }
     
+    
+    
+    
+    
+    func testManagedObjectDeletableAndCountFor() throws {
+        let b = backgroundContext
+        let c = viewContext
+        
+        b.clearAll()
+        c.clearAll()
+        
+        CoreDataPlus.config = nil
+        CoreDataPlus.setup(viewContext: c, backgroundContext: b, logHandler: { _ in
+            
+        })
+        
+        let usa = Country.findOrCreate(id: "1")
+        let japan = Country.findOrCreate(id: "2")
+        let mexico = Country.findOrCreate(id: "3")
+        
+        let nyc = City.findOrCreate(id: "nyc-1", context: c)
+        let tokyo = City.findOrCreate(id: "japan-1", context: c)
+        
+        let enUS = Language.findOrCreate(column: "langCode", value: "en-us", context: c)
+        let jp1 = Language.findOrCreate(column: "langCode", value: "jp", context: c)
+        let es = Language.findOrCreate(column: "langCode", value: "es", context: c)
+        
+        nyc.country = usa
+        tokyo.country = japan
+        
+        usa.addToLanguages(enUS)
+        usa.addToLanguages(es)
+        japan.addToLanguages(jp1)
+        mexico.addToLanguages(es)
+        
+        let withSpanishLanguage = Predicate("languages contains %@", es)
+        XCTAssertEqual(Country.countFor(withSpanishLanguage), 2)
+        
+        Country.destroyAll(matching: withSpanishLanguage)
+        
+        XCTAssertEqual(Country.countFor(withSpanishLanguage), 0)
+        
+    }
+    
+    
     func testManagedObjectSearchable() throws {
         let b = backgroundContext
         let c = viewContext


### PR DESCRIPTION
- Added ability to delete only some items: `Country.destroyAll(matching: withSpanishLanguage)`
- `destroyAll(...)` no longer automatically saves the context
- Tests for destroyAll and `countFor(...)`

## Details on `destroyAll(...)`:
Removes all objects from Core Data.
*Deletes them from the context.*

```swift
Drawing.destroyAll(context: viewContext)
```


You can also specify a predicate to only delete some items:
```swift
let withSpanishLanguage = Predicate("languages contains %@", es)
Country.destroyAll(matching: withSpanishLanguage)
```

Remember to save the context after deleting objects.